### PR TITLE
Profile UI fixes

### DIFF
--- a/app/assets/stylesheets/stylesheet.css.erb
+++ b/app/assets/stylesheets/stylesheet.css.erb
@@ -1255,7 +1255,7 @@ span.right { float: right; }
 
 .be-user-detail { text-align: centre; margin-bottom: 30px;}
 
-.be-ava-user { width: 70px; height: 70px; display: inline-block; margin-bottom: 25px; }
+.be-ava-user { width: 70px; height: 70px; display: inline;block; margin-bottom: 25px; }
 
 .be-ava-user > img { width: 70px; height: 70px; }
 
@@ -1378,7 +1378,7 @@ a.social-btn:hover { opacity: 0.6; color: #fff; }
 
 .be-user-block.style-2 .be-user-detail, .be-user-block.style-3 .be-user-detail { margin-bottom: 60px; }
 
-.be-user-block.style-3 { padding: 30px 15px 0px 15px; margin-bottom: 48px; }
+.be-user-block.style-3 { padding: 30px 15px 0px 15px; margin-bottom: 48px; height: 100%}
 
 .be-ava-user.style-2 { width: 115px; height: 115px; }
 
@@ -1412,7 +1412,11 @@ a.social-btn:hover { opacity: 0.6; color: #fff; }
 
 .be-desc-block { margin-bottom: 20px; }
 
-.be-desc-author { position: relative; padding: 20px 30px; border: 1px solid #222835; min-height: 170px; }
+.be-desc-author { position: relative; 
+                  padding: 20px 30px; 
+                  border: 1px solid #222835; 
+                  height: 100%;
+                  }
 
 .be-desc-img { float: left; width: 70px; height: 70px; margin-bottom: 15px; border-radius: 70px; }
 
@@ -3102,6 +3106,25 @@ transition: all ease-out 0.3s;}
 
 }
 
+<%# Profile Page Styling %>
+.left-box {
+  <%# background-color: #0000FF; %>
+  height: 100%;
+}
+
+.right-box {
+  height: 100%;
+}
+
+.top-right-box {
+  margin-bottom: 25px;
+  height: 199px
+}
+
+.bottom-right-box {
+  height: 199px;
+}
+
 .s-cover-box {
     max-width: 720px;
     width: 100%;
@@ -3851,8 +3874,8 @@ body .login-user-down:hover {
   background: #fffffff0;
   padding: 1px;
   margin-bottom: 5px !important;
-    padding-top: 50px;
-
+  height: 425px;
+  margin-top:50px;
 }
 /*Mobile View of my profile view*/
 @media screen and (min-width:0px) and (max-width:560px) {

--- a/app/views/show_profile/show_profile.html.erb
+++ b/app/views/show_profile/show_profile.html.erb
@@ -124,7 +124,7 @@
 		<% end %>
 		<div class="container be-detail-container">
 			<div class="row profile-row">
-				<div class="col-xs-12 col-md-6 left-field">
+				<div class="col-xs-12 col-md-6 left-box">
 					<div class="be-user-block style-3">
 						<div class="be-user-detail">
 							<% if @general_info.profile_picture.url %>
@@ -157,16 +157,17 @@
 							</div>
 							<div class="be-user-social">
 								<!--% if @general_info && @general_info.facebook_link != "" %-->							
-									<a class="social-btn color-1" href="http://<%= @general_info.facebook_link%>" target="_blank"><i class="fa fa-facebook"></i></a>
+									<a class="social-btn color-1" href=<%= @general_info.facebook_link.blank? ? "#" : @general_info.facebook_link%> target="_blank"><i class="fa fa-facebook"></i></a>
 								<!--% end %-->
 								<!--% if @general_info && @general_info.linkedIn_link != "" %-->
-									<a class="social-btn color-6" href="http://<%= @general_info.linkedIn_link %>" target="_blank"><i class="fa fa-linkedin"></i></a>
+
+								<a class="social-btn color-6" href=<%= @general_info.linkedIn_link.blank? ? "#" : @general_info.linkedIn_link%> target="_blank"><i class="fa fa-linkedin"></i></a>
 								<!--% end %-->
 								<!--% if @login_info && @login_info.email != "" %-->
-									<a class="social-btn color-3" href="mailto:<%= @login_info.email %>"><i class="fa fa-envelope"></i></a>
+								<a class="social-btn color-3" href="mailto:<%= @login_info.email %>"><i class="fa fa-envelope"></i></a>
 								<!--% end %-->
 
-								<a class="be-user-site" href="http://<%= @general_info.personalWebsite_link %>" target="_blank"><i class="fa fa-link"></i> <%= @general_info.personalWebsite_link %></a>
+								<a class="be-user-site" href=<%= @general_info.personalWebsite_link %> target="_blank"><i class="fa fa-link"></i> <%= @general_info.personalWebsite_link %></a>
 								<!--% end %-->
 								<% if @on_Own %>
 									<a class="social-btn color-4" href="/dm"><i class="fa fa-message"></i></a>
@@ -178,8 +179,8 @@
 						</div>
 					</div>
 				</div>
-				<div class="col-xs-12 col-md-6 left-field">
-					<div class="be-desc-block">
+				<div class="col-xs-12 col-md-6 right-box">
+					<div class="top-right-box">
 				  		<!--% if @general_info && @general_info.bio != "" %-->
 							<div class="be-desc-author">
 								<div class="be-desc-label">About Me</div>
@@ -192,14 +193,17 @@
 						<!--% end %-->
 					</div>
 
-					<div class="be-desc-block">
+					<div class="bottom-right-box">
 						<!--% if @general_info && @general_info.bio != "" %-->
 						<div class="be-desc-author">
 							<div class="be-desc-label">Professional Details</div>
 							<div class="clearfix"></div>
 							<div class="be-desc-text">
 								<!--Add Bio HERE-->
+								<%=	@general_info.specialization %>
 								<%= @general_info.profdetails %>
+								<p>Compensation Type: <%=@general_info.compensation%></p>
+								<p>Years of Experience: <%=@general_info.experience%></p>
 							</div>
 						</div>
 						<!--% end %-->

--- a/app/views/show_profile/show_profile.html.erb
+++ b/app/views/show_profile/show_profile.html.erb
@@ -148,7 +148,7 @@
 
 
 
-							<p style="font-size: 12px; margin-top:0px; text-align: left; margin-left: 30px; margin-bottom: 40px;"><%= @general_info.highlights %></p>
+							<p style="font-size: 12px; margin-top:0px; text-align: left; margin-left: 30px; margin-bottom: 40px; height: 80px"><%= @general_info.highlights %></p>
 							
 							<!--<img src="img/ava_10.jpg" alt=""> -->
 							

--- a/app/views/show_profile/show_profile.html.erb
+++ b/app/views/show_profile/show_profile.html.erb
@@ -185,7 +185,7 @@
 							<div class="be-desc-author">
 								<div class="be-desc-label">About Me</div>
 								<div class="clearfix"></div>
-								<div class="be-desc-text">
+								<div class="be-user-detail">
 									<!--Add Bio HERE-->
 									<%= @general_info.bio %>
 								</div>
@@ -198,10 +198,9 @@
 						<div class="be-desc-author">
 							<div class="be-desc-label">Professional Details</div>
 							<div class="clearfix"></div>
-							<div class="be-desc-text">
+							<div class="be-user-detail">
 								<!--Add Bio HERE-->
-								<%=	@general_info.specialization %>
-								<%= @general_info.profdetails %>
+								<p ><strong><%=	@general_info.specialization %>:</strong> <%= @general_info.profdetails %></p>
 								<p>Compensation Type: <%=@general_info.compensation%></p>
 								<p>Years of Experience: <%=@general_info.experience%></p>
 							</div>


### PR DESCRIPTION
Fixed all the UI changes specified by Tito as below except for the one in bold (being completed by Vicente).

- Major disparity between the user's Profile display and the information fields in Edit profile
    -- text in the Professional Specialization edit-box should be displayed in the top line in Professional Details display-box. Currently, it isn't displayed anywhere. 
    -- Text in About Me edit-box isn't displayed in About Me display-box. Old text in the edit-box isn't editable 
**- In Edit profile mode it's again asking for Location info. It should be there once profile is made or edited.** 
- None of the Social Media or web links are working as the app is adding characters when it tries to open the URLs to the URLs I added in the profile by copying and pasting the actual URLs. 
- Compensation Type and Years in Experience should be displayed at the Bottom line of Professional Details. 
- Make the Display Boxes on right side (About Me and Professional Details) such that combined they are same height as About me. For being visually pleasing. Make sure with max size of text they can fit in those boxes